### PR TITLE
Use filereadable() instead of executable()

### DIFF
--- a/autoload/snowdrop.vim
+++ b/autoload/snowdrop.vim
@@ -42,7 +42,7 @@ endfunction
 
 function! snowdrop#get_libclang_version(...)
 	let libclang = get(a:, 1, snowdrop#get_libclang_filename())
-	if empty(executable(libclang))
+	if empty(filereadable(libclang))
 		call snowdrop#echoerr("Not found libclang file : " . libclang)
 		return snowdrop#echoerr("Please set 'g:snowdrop#libclang_directory'")
 	endif

--- a/autoload/snowdrop/libclang.vim
+++ b/autoload/snowdrop/libclang.vim
@@ -24,7 +24,7 @@ endfunction
 
 function! snowdrop#libclang#load(...)
 	let libclang = get(a:, 1, snowdrop#get_libclang_filename())
-	if executable(libclang) != 1
+	if filereadable(libclang) != 1
 		return snowdrop#echoerr("Not found libclang : " . libclang)
 	endif
 endfunction


### PR DESCRIPTION
Hi.

I'm not sure if you used the executable() function for checking the presence of the clang library on Windows because it does some automatic file discovery (I don't have Windows to try now), but on Linux certainly is not going to work, since libraries don't need the executable bit, and rarely have it.

This small change works for me for finding the library. Let me know if you think is wrong on Windows or Mac, and I will try to test it there.
